### PR TITLE
sm8450-common: Fix user builds

### DIFF
--- a/sepolicy/vendor/hal_citsensorservice_xiaomi.te
+++ b/sepolicy/vendor/hal_citsensorservice_xiaomi.te
@@ -47,4 +47,4 @@ allowxperm vendor_hal_citsensorservice_xiaomi_default self:socket ioctl { 0xc300
 allowxperm vendor_hal_citsensorservice_xiaomi_default self:qipcrtr_socket ioctl { 0xc300 0xc301 0xc302 0xc303 0xc304 0xc305 };
 
 get_prop(vendor_hal_citsensorservice_xiaomi_default, vendor_sensors_prop)
-get_prop(vendor_hal_citsensorservice_xiaomi_default, vendor_sensors_debug_prop)
+userdebug_or_eng(`get_prop(vendor_hal_citsensorservice_xiaomi_default, vendor_sensors_debug_prop)');


### PR DESCRIPTION
`device/qcom/sepolicy_vndr` only includes the files that define `vendor_sensors_debug_prop` on eng and userdebug builds (see https://github.com/LineageOS/android_device_qcom_sepolicy_vndr/blob/lineage-20.0/SEPolicy.mk#L55 and https://github.com/LineageOS/android_device_qcom_sepolicy_vndr/blob/lineage-20.0/generic/vendor/test/property.te#L32), so we have to wrap access to it in a call to `userdebug_or_eng`.