### PR TITLE
Add support for recovery battery stat reporting and usb otg

### DIFF
--- a/modules.list.second_stage
+++ b/modules.list.second_stage
@@ -227,3 +227,9 @@ qrtr-mhi.ko
 qrtr-gunyah.ko
 msm_drm.ko
 msm-mmrm.ko
+spf_core_dlkm.ko
+gpr_dlkm.ko
+snd_event_dlkm.ko
+q6_notifier_dlkm.ko
+q6_pdr_dlkm.ko
+adsp_loader_dlkm.ko

--- a/modules.list.vendor_dlkm
+++ b/modules.list.vendor_dlkm
@@ -1,16 +1,10 @@
-q6_notifier_dlkm.ko
-spf_core_dlkm.ko
 audpkt_ion_dlkm.ko
-gpr_dlkm.ko
 audio_pkt_dlkm.ko
 q6_dlkm.ko
-adsp_loader_dlkm.ko
 audio_prm_dlkm.ko
-q6_pdr_dlkm.ko
 pinctrl_lpi_dlkm.ko
 swr_dlkm.ko
 swr_ctrl_dlkm.ko
-snd_event_dlkm.ko
 wcd_core_dlkm.ko
 mbhc_dlkm.ko
 swr_dmic_dlkm.ko

--- a/rootdir/etc/init.recovery.qcom.rc
+++ b/rootdir/etc/init.recovery.qcom.rc
@@ -25,6 +25,9 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+on early-init
+    write /proc/sys/kernel/firmware_config/force_sysfs_fallback 1
+
 on init
     write /sys/class/backlight/panel0-backlight/brightness 200
     setprop sys.usb.configfs 1
@@ -32,9 +35,15 @@ on init
 on property:ro.boot.usbcontroller=*
     setprop sys.usb.controller ${ro.boot.usbcontroller}
     wait /sys/bus/platform/devices/${ro.boot.usb.dwc3_msm:-a600000.ssusb}/mode
-    write /sys/bus/platform/devices/${ro.boot.usb.dwc3_msm:-a600000.ssusb}/mode peripheral
     wait /sys/class/udc/${ro.boot.usbcontroller} 1
 
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
+
+    # Load ADSP firmware for PMIC
+    mkdir /firmware
+    mount vfat /dev/block/bootdevice/by-name/modem${ro.boot.slot_suffix} /firmware ro context=u:object_r:firmware_file:s0
+
+on property:dev.mnt.blk.firmware=*
+    write /sys/kernel/boot_adsp/boot 1

--- a/rootdir/etc/recovery.fstab
+++ b/rootdir/etc/recovery.fstab
@@ -33,6 +33,8 @@ vendor                                                  /vendor                e
 odm                                                     /odm                   ext4    ro,barrier=1,discard                                 wait,slotselect,avb,logical,first_stage_mount
 /dev/block/bootdevice/by-name/metadata                  /metadata              ext4    noatime,nosuid,nodev,discard                         wait,check,formattable,wrappedkey,first_stage_mount
 /dev/block/bootdevice/by-name/userdata                  /data                  f2fs    noatime,nosuid,nodev,discard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier    latemount,wait,check,formattable,fileencryption=ice,wrappedkey,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M,sysfs_path=/sys/devices/platform/soc/1d84000.ufshc,checkpoint=fs
+/devices/platform/soc/8804000.sdhci/mmc_host*           /storage/sdcard1       vfat    nosuid,nodev                                         wait,voldmanaged=sdcard1:auto,encryptable=footer
+/devices/platform/soc/*.ssusb/*.dwc3/xhci-hcd.*.auto*   /storage/usbotg        vfat    nosuid,nodev                                         wait,voldmanaged=usbotg:auto
 /dev/block/mmcblk0p1                       /sdcard         vfat    nosuid,nodev                                               wait
 /dev/block/bootdevice/by-name/boot         /boot           emmc    defaults                                                   defaults
 /dev/block/bootdevice/by-name/misc         /misc           emmc    defaults                                                   defaults


### PR DESCRIPTION
Required commit for recovery battery stat reporting:

device/qcom/sepolicy_vndr/sm8450
https://review.lineageos.org/c/LineageOS/android_device_qcom_sepolicy_vndr/+/398452
https://review.lineageos.org/c/LineageOS/android_device_qcom_sepolicy_vndr/+/398453

Test: build, boot into recovery, check recovery battery stat and usb-otg works